### PR TITLE
fix(caddy): fixed caddy uri

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk update && \
 # Install Caddy
 # Refs:
 # - https://github.com/ZZROTDesign/alpine-caddy
-# - https://github.com/mholt/caddy
+# - https://github.com/caddyserver/caddy
 # -------------------------------------------------------------------------------------------------------------------------------------------------------------------
 RUN apk update && \
     apk --no-cache add \
@@ -20,7 +20,7 @@ RUN apk update && \
         curl
 
 # Install Caddy Server, and All Middleware
-RUN curl -L "https://github.com/mholt/caddy/releases/download/v0.11.1/caddy_v0.11.1_linux_amd64.tar.gz" \
+RUN curl -L "https://github.com/caddyserver/caddy/releases/download/v0.11.1/caddy_v0.11.1_linux_amd64.tar.gz" \
     | tar --no-same-owner -C /usr/bin/ -xz caddy
 
 # Remove build devs

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Based on `openjdk:jre-alpine` the resulting image generates the database documen
 
 The open source SchemaSpy project is located here: https://github.com/schemaspy/schemaspy
 
-The open source Caddy project is located here; https://github.com/mholt/caddy
+The open source Caddy project is located here: https://github.com/caddyserver/caddy
 
 ## Configuration
 


### PR DESCRIPTION
The Caddy Server repository address is changed from https://github.com/mholt/caddy to https://github.com/caddyserver/caddy.